### PR TITLE
修改了匹配 CPU 核心数的正则表达式。

### DIFF
--- a/src/utils/host.js
+++ b/src/utils/host.js
@@ -35,7 +35,7 @@ export function getCPUInfo(text) {
   const companyReg = /Intel|AMD|ARM|Qualcomm|Apple|Samsung|IBM|NVIDIA/;
   // eslint-disable-next-line max-len, vue/max-len
   const modelReg = /Xeon|Threadripper|Athlon|Pentium|Celeron|Opteron|Phenom|Turion|Sempron|FX|A-Series|R-Series|EPYC|Ryzen/;
-  const coresReg = /(\d+) (Virtual|Physics) Core/;
+  const coresReg = /(\d+) (Virtual|Physics|Physical) Core/;
   const companyMatch = text.match(companyReg);
   const modelMatch = text.match(modelReg);
   const coresMatch = text.match(coresReg);


### PR DESCRIPTION
[Issue](https://github.com/hi2shark/nazhua/issues/1)

查看了一下源代码，找到原因了。
我的 CPUID 字符串是：Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz 28 Physical Core，特征为 Physical 而不是 Physics。
宿主机是 ESXi 虚拟化，可能 PVE 的是 Physics Core，但我不太清楚。加一个或条件应该可以了。